### PR TITLE
Fix bash script

### DIFF
--- a/.make/Makefile.lnx
+++ b/.make/Makefile.lnx
@@ -1,3 +1,6 @@
+ # Use bash syntax
+SHELL := /bin/bash
+
 BINARY_SERVER_BIN=$(INSTALL_PREFIX)/fabric8-tenant
 DEP_BIN=dep
 GOAGEN_BIN=$(VENDOR_DIR)/github.com/goadesign/goa/goagen/goagen

--- a/.make/test.mk
+++ b/.make/test.mk
@@ -142,6 +142,7 @@ $(eval FLAG=$(1))
   	>&2 echo ERROR: the sha $${TEMPLATE_SHA} of the file $${TEMPLATE_FILE} is not the latest one; \
   	exit 1; \
   fi; \
+  echo SHA of $${TEMPLATE_FILE}: $${TEMPLATE_SHA}; \
 fi;
 endef
 


### PR DESCRIPTION
In some flavors of linux make use sh instead of bash by default.
This PR fixes the problem.

Also adding echo of found template shas in the test.